### PR TITLE
Enable delete branch on merge for serializer repo

### DIFF
--- a/otterdog/eclipse-serializer.jsonnet
+++ b/otterdog/eclipse-serializer.jsonnet
@@ -27,7 +27,7 @@ orgs.newOrg('technology.serializer', 'eclipse-serializer') {
     orgs.newRepo('serializer') {
       allow_merge_commit: true,
       allow_update_branch: false,
-      delete_branch_on_merge: false,
+      delete_branch_on_merge: true,
       description: "Serializer project",
       has_discussions: true,
       homepage: "",


### PR DESCRIPTION
This pull request makes a small configuration change to the `serializer` repository. The change ensures that branches are automatically deleted after a pull request is merged, helping keep the repository clean.